### PR TITLE
Migrate functions from GraphQL API

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.12.0-alpha
+current_version = 0.12.0-alpha.1
 commit = True
 tag = True
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.12.0-alpha.1] - 2024-06-19
+## Added
+- `SetOperationEnum` for set joining operations
+- `InversionSolutionOperations.get_rupture_ids_for_fault_names`
+- `InversionSolutionOperations.get_rupture_ids_for_location_radius`
+## Changed
+- Updated dependencies:
+    - nzhsm-common to ^0.7
+    - nzshm-model to ^0.6 (will need further refactoring for higher versions)
+- `circle_polygon` radius typed for float, so it can work work floats or ints
+## Deprecated
+- `get_ruptures_intersecting` renamed to `get_rupture_ids_intersecting`
+- `get_ruptures_for_parent_fault` renamed to `get_rupture_ids_for_parent_fault`
+
+
 ## [0.12.0-alpha] - 2024-06-14
 ## Added
 - Support for Python 3.10, 3.11

--- a/docs/api/inversion_solution/inversion_solution_operations.md
+++ b/docs/api/inversion_solution/inversion_solution_operations.md
@@ -1,1 +1,5 @@
 ::: solvis.inversion_solution.inversion_solution_operations
+    options:
+        filters:
+        - "!^_[^_]"
+        - "!^get_ruptures_"  # Deprecated function signatures

--- a/docs/api/solvis/geometry.md
+++ b/docs/api/solvis/geometry.md
@@ -1,1 +1,3 @@
 ::: solvis.geometry
+    options:
+        annotations_path: full

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -92,7 +92,7 @@ plugins:
             show_signature_annotations: true
             show_if_no_docstring: true
             signature_crossrefs: true
-            annotations_path: full
+            annotations_path: source
             # show_source: true
 
 extra:

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,17 +288,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.34.128"
+version = "1.34.129"
 description = "The AWS SDK for Python"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.128-py3-none-any.whl", hash = "sha256:a048ff980a81cd652724a73bc496c519b336fabe19cc8bfc6c53b2ff6eb22c7b"},
-    {file = "boto3-1.34.128.tar.gz", hash = "sha256:43a6e99f53a8d34b3b4dbe424dbcc6b894350dc41a85b0af7c7bc24a7ec2cead"},
+    {file = "boto3-1.34.129-py3-none-any.whl", hash = "sha256:cc73de1c9d953b1f9da6ee2404af717e93d888f790f3e0291b22d1b8489eb401"},
+    {file = "boto3-1.34.129.tar.gz", hash = "sha256:a7a696fd3e7f5f43a81450b441f3eb6c5a89d28efe867cd97d8fc73ea5d8c139"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.128,<1.35.0"
+botocore = ">=1.34.129,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -307,13 +307,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.128"
+version = "1.34.129"
 description = "Low-level, data-driven core of boto 3."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.128-py3-none-any.whl", hash = "sha256:db67fda136c372ab3fa432580c819c89ba18d28a6152a4d2a7ea40d44082892e"},
-    {file = "botocore-1.34.128.tar.gz", hash = "sha256:8d8e03f7c8c080ecafda72036eb3b482d649f8417c90b5dca33b7c2c47adb0c9"},
+    {file = "botocore-1.34.129-py3-none-any.whl", hash = "sha256:86d3dd30996aa459e9c3321edac12aebe47c73cb4acc7556941f9b4c39726088"},
+    {file = "botocore-1.34.129.tar.gz", hash = "sha256:7c56e25af6112d69c5d14a15b42f76ba7687687abc463a96ac5edca19c0a9c2d"},
 ]
 
 [package.dependencies]
@@ -1371,13 +1371,13 @@ files = [
 
 [[package]]
 name = "griffe"
-version = "0.46.1"
+version = "0.47.0"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.46.1-py3-none-any.whl", hash = "sha256:e74dd71690a6bc339916f31aec4912fcb29a67294b7a557be7f80c3131f4ec6e"},
-    {file = "griffe-0.46.1.tar.gz", hash = "sha256:cbf12fb5686110b5c1a956520079cd1656e2ea0b80b63f33ad9d9e21545af2a5"},
+    {file = "griffe-0.47.0-py3-none-any.whl", hash = "sha256:07a2fd6a8c3d21d0bbb0decf701d62042ccc8a576645c7f8799fe1f10de2b2de"},
+    {file = "griffe-0.47.0.tar.gz", hash = "sha256:95119a440a3c932b13293538bdbc405bee4c36428547553dc6b327e7e7d35e5a"},
 ]
 
 [package.dependencies]
@@ -2318,17 +2318,17 @@ python-legacy = ["mkdocstrings-python-legacy (>=0.2.1)"]
 
 [[package]]
 name = "mkdocstrings-python"
-version = "1.10.3"
+version = "1.10.4"
 description = "A Python handler for mkdocstrings."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocstrings_python-1.10.3-py3-none-any.whl", hash = "sha256:11ff6d21d3818fb03af82c3ea6225b1534837e17f790aa5f09626524171f949b"},
-    {file = "mkdocstrings_python-1.10.3.tar.gz", hash = "sha256:321cf9c732907ab2b1fedaafa28765eaa089d89320f35f7206d00ea266889d03"},
+    {file = "mkdocstrings_python-1.10.4-py3-none-any.whl", hash = "sha256:55141806a463fedad0d8d405088612aaea7efa518aa24d4a6227021775c44369"},
+    {file = "mkdocstrings_python-1.10.4.tar.gz", hash = "sha256:629a7d8bdd38358275dd44078bfc560f85e62ad3f244816b04783f30c4e2fea0"},
 ]
 
 [package.dependencies]
-griffe = ">=0.44"
+griffe = ">=0.47"
 mkdocstrings = ">=0.25"
 
 [[package]]
@@ -2594,19 +2594,18 @@ geometry = ["shapely (>=2.0.2,<3.0.0)"]
 
 [[package]]
 name = "nzshm-model"
-version = "0.9.3"
+version = "0.6.1"
 description = "The logic tree definitions, final configurations, and versioning of the New Zealand | Aotearoa National Seismic Hazard Model"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "nzshm_model-0.9.3-py3-none-any.whl", hash = "sha256:b664e582680681c1b4e5c2b4fbb8cb919fe4a9a93d3cc22afe4b05ab3ac7ab5f"},
-    {file = "nzshm_model-0.9.3.tar.gz", hash = "sha256:982d23005d4ea9f8b37e67b70b55467b21b37857204ad351eb34f2d808b8a98a"},
+    {file = "nzshm_model-0.6.1-py3-none-any.whl", hash = "sha256:0ff94f330dad9a6c4a5526a95c370acb30eecd229b8628256baffe5810cc52b0"},
+    {file = "nzshm_model-0.6.1.tar.gz", hash = "sha256:d4651f53c3458f4b3a85a66344c8ca549435605b9da1845422910ef387d47d83"},
 ]
 
 [package.dependencies]
 dacite = ">=1.6.0,<2.0.0"
 lxml = ">=4.9.3,<5.0.0"
-mkdocstrings-python = ">=1.8.0,<2.0.0"
 
 [package.extras]
 scripts = ["click[scripts] (>=8.1.3,<9.0.0)"]
@@ -4234,4 +4233,4 @@ vtk = ["pyvista"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "d5596361534ebaee186e7f2cb2dc04fd99c64edb4c00e122a0c7e0014d07632c"
+content-hash = "f6b0a305b1d4f1b5124cd25d8198a09f962e10d71f21b68363cf47a6d428364c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -288,17 +288,17 @@ uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
 name = "boto3"
-version = "1.34.120"
+version = "1.34.128"
 description = "The AWS SDK for Python"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.34.120-py3-none-any.whl", hash = "sha256:3c42bc309246a761413f6e152f307f009e80e7c9fd03dd9e6c0dc8ab8b3a8fc1"},
-    {file = "boto3-1.34.120.tar.gz", hash = "sha256:38893db8269d25b72cc6fbab97633bfc863eefde5456847169d06149a16aa6e0"},
+    {file = "boto3-1.34.128-py3-none-any.whl", hash = "sha256:a048ff980a81cd652724a73bc496c519b336fabe19cc8bfc6c53b2ff6eb22c7b"},
+    {file = "boto3-1.34.128.tar.gz", hash = "sha256:43a6e99f53a8d34b3b4dbe424dbcc6b894350dc41a85b0af7c7bc24a7ec2cead"},
 ]
 
 [package.dependencies]
-botocore = ">=1.34.120,<1.35.0"
+botocore = ">=1.34.128,<1.35.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.10.0,<0.11.0"
 
@@ -307,13 +307,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.34.120"
+version = "1.34.128"
 description = "Low-level, data-driven core of boto 3."
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.34.120-py3-none-any.whl", hash = "sha256:92bd739938078c7a0b110689a3eee21ecb3954d90653da013d9f98ef1165d6f7"},
-    {file = "botocore-1.34.120.tar.gz", hash = "sha256:5cc0fca43cb2aad54917a394a001ac9ba774d21ad6a08828002d54b601776f78"},
+    {file = "botocore-1.34.128-py3-none-any.whl", hash = "sha256:db67fda136c372ab3fa432580c819c89ba18d28a6152a4d2a7ea40d44082892e"},
+    {file = "botocore-1.34.128.tar.gz", hash = "sha256:8d8e03f7c8c080ecafda72036eb3b482d649f8417c90b5dca33b7c2c47adb0c9"},
 ]
 
 [package.dependencies]
@@ -325,7 +325,7 @@ urllib3 = [
 ]
 
 [package.extras]
-crt = ["awscrt (==0.20.9)"]
+crt = ["awscrt (==0.20.11)"]
 
 [[package]]
 name = "bracex"
@@ -1040,18 +1040,18 @@ tests = ["asttokens (>=2.1.0)", "coverage", "coverage-enable-subprocess", "ipyth
 
 [[package]]
 name = "filelock"
-version = "3.14.0"
+version = "3.15.1"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "filelock-3.14.0-py3-none-any.whl", hash = "sha256:43339835842f110ca7ae60f1e1c160714c5a6afd15a2873419ab185334975c0f"},
-    {file = "filelock-3.14.0.tar.gz", hash = "sha256:6ea72da3be9b8c82afd3edcf99f2fffbb5076335a5ae4d03248bb5b6c3eae78a"},
+    {file = "filelock-3.15.1-py3-none-any.whl", hash = "sha256:71b3102950e91dfc1bb4209b64be4dc8854f40e5f534428d8684f953ac847fac"},
+    {file = "filelock-3.15.1.tar.gz", hash = "sha256:58a2549afdf9e02e10720eaa4d4470f56386d7a6f72edd7d0596337af8ed7ad8"},
 ]
 
 [package.extras]
 docs = ["furo (>=2023.9.10)", "sphinx (>=7.2.6)", "sphinx-autodoc-typehints (>=1.25.2)"]
-testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
+testing = ["covdefaults (>=2.3)", "coverage (>=7.3.2)", "diff-cover (>=8.0.1)", "pytest (>=7.4.3)", "pytest-asyncio (>=0.21)", "pytest-cov (>=4.1)", "pytest-mock (>=3.12)", "pytest-timeout (>=2.2)"]
 typing = ["typing-extensions (>=4.8)"]
 
 [[package]]
@@ -1371,13 +1371,13 @@ files = [
 
 [[package]]
 name = "griffe"
-version = "0.45.2"
+version = "0.46.1"
 description = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "griffe-0.45.2-py3-none-any.whl", hash = "sha256:297ec8530d0c68e5b98ff86fb588ebc3aa3559bb5dc21f3caea8d9542a350133"},
-    {file = "griffe-0.45.2.tar.gz", hash = "sha256:83ce7dcaafd8cb7f43cbf1a455155015a1eb624b1ffd93249e5e1c4a22b2fdb2"},
+    {file = "griffe-0.46.1-py3-none-any.whl", hash = "sha256:e74dd71690a6bc339916f31aec4912fcb29a67294b7a557be7f80c3131f4ec6e"},
+    {file = "griffe-0.46.1.tar.gz", hash = "sha256:cbf12fb5686110b5c1a956520079cd1656e2ea0b80b63f33ad9d9e21545af2a5"},
 ]
 
 [package.dependencies]
@@ -2200,13 +2200,13 @@ pyyaml = ">=5.1"
 
 [[package]]
 name = "mkdocs-include-markdown-plugin"
-version = "6.1.1"
+version = "6.2.0"
 description = "Mkdocs Markdown includer plugin."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_include_markdown_plugin-6.1.1-py3-none-any.whl", hash = "sha256:b05dc442bd5ffc34694e96c41ee23f7cea0d34f11bdbe0186f8a3a4407e8ddd4"},
-    {file = "mkdocs_include_markdown_plugin-6.1.1.tar.gz", hash = "sha256:5f1d6e4a49e43a4d0139e5a20a74caccc390fb65f24f7616d960211502a548d5"},
+    {file = "mkdocs_include_markdown_plugin-6.2.0-py3-none-any.whl", hash = "sha256:32f03b127369b79df803eca2490e5564e38ae72108d6a4292f3717ca684ed1fc"},
+    {file = "mkdocs_include_markdown_plugin-6.2.0.tar.gz", hash = "sha256:c9f63eeebc0e34d64236c88f3cf6696c03ca99d74e4b57fe86701e8942d53ba5"},
 ]
 
 [package.dependencies]
@@ -2218,13 +2218,13 @@ cache = ["platformdirs"]
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.25"
+version = "9.5.27"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.25-py3-none-any.whl", hash = "sha256:68fdab047a0b9bfbefe79ce267e8a7daaf5128bcf7867065fcd201ee335fece1"},
-    {file = "mkdocs_material-9.5.25.tar.gz", hash = "sha256:d0662561efb725b712207e0ee01f035ca15633f29a64628e24f01ec99d7078f4"},
+    {file = "mkdocs_material-9.5.27-py3-none-any.whl", hash = "sha256:af8cc263fafa98bb79e9e15a8c966204abf15164987569bd1175fd66a7705182"},
+    {file = "mkdocs_material-9.5.27.tar.gz", hash = "sha256:a7d4a35f6d4a62b0c43a0cfe7e987da0980c13587b5bc3c26e690ad494427ec0"},
 ]
 
 [package.dependencies]
@@ -2333,13 +2333,13 @@ mkdocstrings = ">=0.25"
 
 [[package]]
 name = "more-itertools"
-version = "10.2.0"
+version = "10.3.0"
 description = "More routines for operating on iterables, beyond itertools"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "more-itertools-10.2.0.tar.gz", hash = "sha256:8fccb480c43d3e99a00087634c06dd02b0d50fbf088b380de5a41a015ec239e1"},
-    {file = "more_itertools-10.2.0-py3-none-any.whl", hash = "sha256:686b06abe565edfab151cb8fd385a05651e1fdf8f0a14191e4439283421f8684"},
+    {file = "more-itertools-10.3.0.tar.gz", hash = "sha256:e5d93ef411224fbcef366a6e8ddc4c5781bc6359d43412a65dd5964e46111463"},
+    {file = "more_itertools-10.3.0-py3-none-any.whl", hash = "sha256:ea6a02e24a9161e51faad17a8782b92a0df82c12c1c8886fec7f0c3fa1a1b320"},
 ]
 
 [[package]]
@@ -2580,32 +2580,33 @@ files = [
 
 [[package]]
 name = "nzshm-common"
-version = "0.4.0"
+version = "0.7.0"
 description = "A small pure python library for shared NZ NSHM data like locations."
 optional = false
-python-versions = ">=3.8,<4.0.0"
+python-versions = "<4.0.0,>=3.8"
 files = [
-    {file = "nzshm-common-0.4.0.tar.gz", hash = "sha256:f0f7d303548c70be0f12c7894b75fcf59a7019f068e9ab71f9c950b9ec63740b"},
-    {file = "nzshm_common-0.4.0-py3-none-any.whl", hash = "sha256:78572dde972362ee3b0c3b5e2633950cf9befcc7ada03a382ad5084e5c148ef1"},
+    {file = "nzshm_common-0.7.0-py3-none-any.whl", hash = "sha256:21187d41fd8a87e0368cd6ef46080a02d7753917aebd287b5df2fe711e71e45e"},
+    {file = "nzshm_common-0.7.0.tar.gz", hash = "sha256:12ff96f2239a8e6345c9201cc45b8a97036085b918790ee9f60c0791d99a90e3"},
 ]
 
 [package.extras]
-geometry = ["Shapely[geometry] (>=1.8.3,<2.0.0)", "geopandas[geometry] (>=0.11.1,<0.12.0)"]
+geometry = ["shapely (>=2.0.2,<3.0.0)"]
 
 [[package]]
 name = "nzshm-model"
-version = "0.4.0"
+version = "0.9.3"
 description = "The logic tree definitions, final configurations, and versioning of the New Zealand | Aotearoa National Seismic Hazard Model"
 optional = false
 python-versions = ">=3.9,<4.0"
 files = [
-    {file = "nzshm_model-0.4.0-py3-none-any.whl", hash = "sha256:ec357ee2fefc7a0d440fff413cc57429888962c23da24585aa208791c971e775"},
-    {file = "nzshm_model-0.4.0.tar.gz", hash = "sha256:827e48e8dd4f4326143527c61d9d6bd946cc1bcfa95733cd6cff889f29d4882c"},
+    {file = "nzshm_model-0.9.3-py3-none-any.whl", hash = "sha256:b664e582680681c1b4e5c2b4fbb8cb919fe4a9a93d3cc22afe4b05ab3ac7ab5f"},
+    {file = "nzshm_model-0.9.3.tar.gz", hash = "sha256:982d23005d4ea9f8b37e67b70b55467b21b37857204ad351eb34f2d808b8a98a"},
 ]
 
 [package.dependencies]
 dacite = ">=1.6.0,<2.0.0"
 lxml = ">=4.9.3,<5.0.0"
+mkdocstrings-python = ">=1.8.0,<2.0.0"
 
 [package.extras]
 scripts = ["click[scripts] (>=8.1.3,<9.0.0)"]
@@ -2613,13 +2614,13 @@ toshi = ["boto3[toshi] (>=1.26.28,<2.0.0)", "nshm-toshi-client[toshi] (>=1.0.1,<
 
 [[package]]
 name = "packaging"
-version = "24.0"
+version = "24.1"
 description = "Core utilities for Python packages"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "packaging-24.0-py3-none-any.whl", hash = "sha256:2ddfb553fdf02fb784c234c7ba6ccc288296ceabec964ad2eae3777778130bc5"},
-    {file = "packaging-24.0.tar.gz", hash = "sha256:eb82c5e3e56209074766e6885bb04b8c38a0c015d0a30036ebe7ece34c9989e9"},
+    {file = "packaging-24.1-py3-none-any.whl", hash = "sha256:5b8f2217dbdbd2f7f384c41c628544e6d52f2d0f53c6d0c3ea61aa5d1d7ff124"},
+    {file = "packaging-24.1.tar.gz", hash = "sha256:026ed72c8ed3fcce5bf8950572258698927fd1dbda10a5e981cdf0ac37f4f002"},
 ]
 
 [[package]]
@@ -2890,13 +2891,13 @@ xmp = ["defusedxml"]
 
 [[package]]
 name = "pkginfo"
-version = "1.11.0"
+version = "1.11.1"
 description = "Query metadata from sdists / bdists / installed packages."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pkginfo-1.11.0-py3-none-any.whl", hash = "sha256:6d4998d1cd42c297af72cc0eab5f5bab1d356fb8a55b828fa914173f8bc1ba05"},
-    {file = "pkginfo-1.11.0.tar.gz", hash = "sha256:dba885aa82e31e80d615119874384923f4e011c2a39b0c4b7104359e36cb7087"},
+    {file = "pkginfo-1.11.1-py3-none-any.whl", hash = "sha256:bfa76a714fdfc18a045fcd684dbfc3816b603d9d075febef17cb6582bea29573"},
+    {file = "pkginfo-1.11.1.tar.gz", hash = "sha256:2e0dca1cf4c8e39644eed32408ea9966ee15e0d324c62ba899a393b3c6b467aa"},
 ]
 
 [package.extras]
@@ -2935,13 +2936,13 @@ testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pooch"
-version = "1.8.1"
-description = "\"Pooch manages your Python library's sample data files: it automatically downloads and stores them in a local directory, with support for versioning and corruption checks.\""
+version = "1.8.2"
+description = "A friend to fetch your data files"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "pooch-1.8.1-py3-none-any.whl", hash = "sha256:6b56611ac320c239faece1ac51a60b25796792599ce5c0b1bb87bf01df55e0a9"},
-    {file = "pooch-1.8.1.tar.gz", hash = "sha256:27ef63097dd9a6e4f9d2694f5cfbf2f0a5defa44fccafec08d601e731d746270"},
+    {file = "pooch-1.8.2-py3-none-any.whl", hash = "sha256:3529a57096f7198778a5ceefd5ac3ef0e4d06a6ddaf9fc2d609b806f25302c47"},
+    {file = "pooch-1.8.2.tar.gz", hash = "sha256:76561f0de68a01da4df6af38e9955c4c9d1a5c90da73f7e40276a5728ec83d10"},
 ]
 
 [package.dependencies]
@@ -2956,13 +2957,13 @@ xxhash = ["xxhash (>=1.4.3)"]
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.46"
+version = "3.0.47"
 description = "Library for building powerful interactive command lines in Python"
 optional = false
 python-versions = ">=3.7.0"
 files = [
-    {file = "prompt_toolkit-3.0.46-py3-none-any.whl", hash = "sha256:45abe60a8300f3c618b23c16c4bb98c6fc80af8ce8b17c7ae92db48db3ee63c1"},
-    {file = "prompt_toolkit-3.0.46.tar.gz", hash = "sha256:869c50d682152336e23c4db7f74667639b5047494202ffe7670817053fd57795"},
+    {file = "prompt_toolkit-3.0.47-py3-none-any.whl", hash = "sha256:0d7bfa67001d5e39d02c224b663abc33687405033a8c422d0d675a5a13361d10"},
+    {file = "prompt_toolkit-3.0.47.tar.gz", hash = "sha256:1e1b29cb58080b1e69f207c893a1a7bf16d127a5c30c9d17a25a5d77792e5360"},
 ]
 
 [package.dependencies]
@@ -3768,13 +3769,13 @@ files = [
 
 [[package]]
 name = "tox"
-version = "4.15.0"
+version = "4.15.1"
 description = "tox is a generic virtualenv management and test command line tool"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "tox-4.15.0-py3-none-any.whl", hash = "sha256:300055f335d855b2ab1b12c5802de7f62a36d4fd53f30bd2835f6a201dda46ea"},
-    {file = "tox-4.15.0.tar.gz", hash = "sha256:7a0beeef166fbe566f54f795b4906c31b428eddafc0102ac00d20998dd1933f6"},
+    {file = "tox-4.15.1-py3-none-any.whl", hash = "sha256:f00a5dc4222b358e69694e47e3da0227ac41253509bca9f45aa8f012053e8d9d"},
+    {file = "tox-4.15.1.tar.gz", hash = "sha256:53a092527d65e873e39213ebd4bd027a64623320b6b0326136384213f95b7076"},
 ]
 
 [package.dependencies]
@@ -3832,13 +3833,13 @@ urllib3 = ">=1.26.0"
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.1"
+version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "typing_extensions-4.12.1-py3-none-any.whl", hash = "sha256:6024b58b69089e5a89c347397254e35f1bf02a907728ec7fee9bf0fe837d203a"},
-    {file = "typing_extensions-4.12.1.tar.gz", hash = "sha256:915f5e35ff76f56588223f15fdd5938f9a1cf9195c0de25130c627e4d597f6d1"},
+    {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
+    {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
 ]
 
 [[package]]
@@ -3854,13 +3855,13 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "1.26.18"
+version = "1.26.19"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
-    {file = "urllib3-1.26.18-py2.py3-none-any.whl", hash = "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"},
-    {file = "urllib3-1.26.18.tar.gz", hash = "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0"},
+    {file = "urllib3-1.26.19-py2.py3-none-any.whl", hash = "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3"},
+    {file = "urllib3-1.26.19.tar.gz", hash = "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"},
 ]
 
 [package.extras]
@@ -4233,4 +4234,4 @@ vtk = ["pyvista"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "7e0c3fa8db5bca767c4a25ba8b46280ec53fbea6728937ef9fc6a07f32bcb711"
+content-hash = "d5596361534ebaee186e7f2cb2dc04fd99c64edb4c00e122a0c7e0014d07632c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "solvis"
-version = "0.12.0-alpha"
+version = "0.12.0-alpha.1"
 description = "analysis of opensha modular solution files."
 authors = ["Chris Chamberlain <chrisbc@artisan.co.nz>"]
 license = "AGPL3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pyvista = {version = "^0.37.0", optional = true, extras = ["vtk"]}
 urllib3 = "<2"
 geopandas = "^0.13.2"
 numpy = "<1.25"
-nzshm-model = {version = "^0.9.0"}
+nzshm-model = {version = "^0.6"}
 
 [tool.poetry.group.dev.dependencies]
 black  = { version = "^22.3"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ pyvista = {version = "^0.37.0", optional = true, extras = ["vtk"]}
 urllib3 = "<2"
 geopandas = "^0.13.2"
 numpy = "<1.25"
-nzshm-model = {version = "^0.4.0"}
+nzshm-model = {version = "^0.9.0"}
 
 [tool.poetry.group.dev.dependencies]
 black  = { version = "^22.3"}
@@ -49,7 +49,7 @@ flake8-docstrings = { version = "^1.6.0", optional = true }
 pytest = { version = "^6.2.4"}
 pytest-cov  = { version = "^2.12.0"}
 twine = "^4.0.2"
-nzshm-common = "^0.4.0"
+nzshm-common = "^0.7.0"
 matplotlib = "^3.6.3"
 tox = "^4.4.4"
 ipython = "^8.11.0"

--- a/solvis/geometry.py
+++ b/solvis/geometry.py
@@ -247,7 +247,7 @@ def dip_direction(point_a: Point, point_b: Point) -> float:
     return dip_dir + 360 if dip_dir < 0 else dip_dir
 
 
-def circle_polygon(radius_m: int, lat: float, lon: float) -> Polygon:
+def circle_polygon(radius_m: float, lat: float, lon: float) -> Polygon:
     """
     Creates a circular `Polygon` at a given radius in metres around the `lat, lon` coordinate.
 

--- a/solvis/inversion_solution/inversion_solution_operations.py
+++ b/solvis/inversion_solution/inversion_solution_operations.py
@@ -203,7 +203,48 @@ class InversionSolutionOperations(InversionSolutionProtocol):
         radius_km: float,
         location_join_type: SetOperationEnum = SetOperationEnum.UNION,
     ) -> Set[int]:
-        """TODO: Docs here"""
+        """
+        Return IDs for ruptures within a radius around one or more locations.
+
+        Where there are multiple locations, the rupture IDs represent a set joining
+        of the specified radii.
+
+        Locations are resolved using [`nzshm-common`](https://pypi.org/project/nzshm-common/)
+        location ID values.
+
+        Parameters:
+            location_ids: one or more defined location IDs
+            radius_km: radius around the point(s) in kilometres
+            location_join_type: UNION or INTERSECTION
+
+        Returns:
+            a Set of rupture IDs
+
+        Examples:
+            Get all rupture IDs from the solution that are within 100km of Blenheim:
+            ```py
+                bhe_rupture_ids = sol.get_rupture_ids_for_location_radius(
+                    location_ids=["BHE"],
+                    radius_km=100,
+                )
+            ```
+            Get all rupture IDs from the solution that are within 50km of Blenheim
+            or within 50km of Wellington:
+            ```py
+                intersect_rupture_ids = sol.get_rupture_ids_for_location_radius(
+                    location_ids=["BHE"],
+                    radius_km=50,
+                    location_joint_type=SetOperationEnum.UNION,
+                )
+            ```
+
+        Note:
+            If you want to do this kind of joining between locations with different
+            radii or points that are not defined by location IDs, consider using
+            [circle_polygon][solvis.geometry.circle_polygon] and
+            [get_rupture_ids_intersecting][solvis.inversion_solution.inversion_solution_operations.InversionSolutionOperations.get_rupture_ids_intersecting]
+            then use set operations to join each rupture ID set.
+        """
         log.info('get_rupture_ids_for_location_radius: %s %s %s' % (self, radius_km, location_ids))
         first = True
         rupture_ids: Set[int]

--- a/solvis/inversion_solution/typing.py
+++ b/solvis/inversion_solution/typing.py
@@ -1,5 +1,6 @@
 import io
 import zipfile
+from enum import Enum
 from pathlib import Path
 from typing import Any, List, Mapping, Optional, Protocol, Union
 
@@ -110,3 +111,11 @@ class BranchSolutionProtocol(InversionSolutionProtocol):
     fault_system: Union[str, None] = ""
     rupture_set_id: Union[str, None] = ""
     branch: ModelLogicTreeBranch
+
+
+class SetOperationEnum(Enum):
+    """Enumerated type for common set operations."""
+
+    UNION = 1
+    INTERSECTION = 2
+    DIFFERENCE = 3

--- a/test/test_inversion_solution.py
+++ b/test/test_inversion_solution.py
@@ -66,13 +66,13 @@ class TestInversionSolution(object):
     def test_get_rupture_ids_for_parent_fault(self, crustal_solution_fixture):
         sol = crustal_solution_fixture
 
-        df0 = set(sol.get_rupture_ids_for_parent_fault("Alpine Kaniere to Springs Junction"))
-        df1 = set(sol.get_rupture_ids_for_parent_fault("Alpine Jacksons to Kaniere"))
-        print(list(df0))
+        pf1_ids = set(sol.get_rupture_ids_for_parent_fault("Alpine Kaniere to Springs Junction"))
+        pf2_ids = set(sol.get_rupture_ids_for_parent_fault("Alpine Jacksons to Kaniere"))
+        print(list(pf1_ids))
 
-        assert df0 is not df1
-        assert len(df0) is not len(df1)
-        assert len(df0.intersection(df1)) > 0
+        assert pf1_ids is not pf2_ids, "Should return different rupture ID sets"
+        assert len(pf1_ids) is not len(pf2_ids), "Sets should have different lengths"
+        assert len(pf1_ids.intersection(pf2_ids)) > 0, "Sets are expected to overlap"
 
     def test_get_rupture_ids_for_fault_names(self, crustal_solution_fixture):
         sol = crustal_solution_fixture
@@ -81,6 +81,8 @@ class TestInversionSolution(object):
         PARENT_FAULT_2 = "Alpine Kaniere to Springs Junction"
         PF1_IDS = set(sol.get_rupture_ids_for_parent_fault(PARENT_FAULT_1))
         PF2_IDS = set(sol.get_rupture_ids_for_parent_fault(PARENT_FAULT_2))
+
+        # Ensure we get the same results as when joining sets manually.
 
         rupture_ids_union = sol.get_rupture_ids_for_fault_names(
             corupture_fault_names=[PARENT_FAULT_1, PARENT_FAULT_2],

--- a/test/test_inversion_solution.py
+++ b/test/test_inversion_solution.py
@@ -6,7 +6,7 @@ import pathlib
 import numpy as np
 import pandas as pd
 from nzshm_common.location.location import location_by_id
-from pytest import approx
+from pytest import approx, raises
 
 from solvis import InversionSolution, circle_polygon
 from solvis.inversion_solution.typing import SetOperationEnum
@@ -92,8 +92,14 @@ class TestInversionSolution(object):
             corupture_fault_names=[PARENT_FAULT_1, PARENT_FAULT_2],
             fault_join_type=SetOperationEnum.INTERSECTION,
         )
-        print("INT", len(rupture_ids_intersection))
+
         assert len(rupture_ids_intersection) == len(PF1_IDS.intersection(PF2_IDS))
+
+        with raises(ValueError):
+            sol.get_rupture_ids_for_fault_names(
+                corupture_fault_names=[PARENT_FAULT_1, PARENT_FAULT_2],
+                fault_join_type=SetOperationEnum.DIFFERENCE,
+            )
 
     def test_slip_rate_soln(self, crustal_solution_fixture):
         sol = crustal_solution_fixture


### PR DESCRIPTION
#37 
Bringing in the following from Solvis GraphQL API:


1. `.filter_set_logic_options.SetOperationEnum(graphene.Enum)`
&rarr;
`.typing.SetOperationEnum(enum.Enum)`


2. `cached.get_rupture_ids_for_fault_names(fault_system_solution, corupture_fault_names, filter_set_options)`
&rarr;
`InversionSolutionOperations.get_rupture_ids_for_fault_names(corupture_fault_names, fault_join_type)`


3. `cached.get_rupture_ids_for_location_radius(fault_system_solution, location_ids, radius_km, filter_set_options)`
&rarr;
`InversionSolutionOperations.get_rupture_ids_for_location_radius(location_ids, radius_km, location_join_type)`

Documented with examples. Tests for these are under `test_inversion_solution.py`.


### Other things
- Updated dependencies:
    - `nzshm-common` &rarr; ^0.7, `nzshm-model` &rarr; ^0.6
- Changed `circle_polygon` radius typing to `float`, since that'll handle both float and int from a MyPy perspective
- Deprecated nearby `get_ruptures_...` methods in favour of a more consistent / explicit `get_rupture_ids_...`
- Updated the tests using the deprecated methods to use the new names