### PR TITLE
make parent fault filter chainable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
  - updated flake8 and applied many docstring fixes.
  - refactored participation methods into module/class.
  - use valid NSHM fault names in docstring examples.
+ - `FilterParentFaultIds` class is now chainable, like the other filters.
 
 ## Added
  - new filter package providing classes for filtering solutions
@@ -31,6 +32,7 @@
  - added participation methods to fault_system_solution
  - a simple rupture grouping algorithm (can this be a different type of filter??);
  - `pandera` library for dataframe model validations and better docs
+ - ChainableSet now supports set.symmetric_difference
 
 ## Removed
  - deprecated `solvis.solvis` functions removed.

--- a/solvis/filter/chainable_set_base.py
+++ b/solvis/filter/chainable_set_base.py
@@ -37,6 +37,8 @@ class ChainableSetBase:
             instance._chained_set = set.union(result, self.chained_set) if self.chained_set else result
         elif join_prior == SetOperationEnum.DIFFERENCE:
             instance._chained_set = set.difference(result, self.chained_set) if self.chained_set else result
+        elif join_prior == SetOperationEnum.SYMMETRIC_DIFFERENCE:
+            instance._chained_set = set.symmetric_difference(result, self.chained_set) if self.chained_set else result
         else:
             raise ValueError(f"Unsupported join type {join_prior}")  # pragma: no cover
         return instance

--- a/solvis/filter/parent_fault_id_filter.py
+++ b/solvis/filter/parent_fault_id_filter.py
@@ -23,9 +23,6 @@ Examples:
             .for_parent_fault_names(['Alpine: Jacksons to Kaniere'])\
             .for_rupture_ids(rupture_ids)
     ```
-
-TODO:
-  - make FilterParentFaultIds chainable
 """
 
 from typing import Iterable, Iterator, NamedTuple, Set, Union

--- a/solvis/filter/rupture_id_filter.py
+++ b/solvis/filter/rupture_id_filter.py
@@ -2,7 +2,7 @@ r"""
 This module provides a class for filtering solution ruptures.
 
 Classes:
- FilterRuptureIds: a filter for ruptures, returning qualifying rupture ids.
+ FilterRuptureIds: a chainable filter for ruptures, returning qualifying rupture ids.
 
 Examples:
     ```py
@@ -10,19 +10,18 @@ Examples:
     >>> ham50 = solvis.circle_polygon(50000, -37.78, 175.28)  # 50km radius around Hamilton
     <POLYGON ((175.849 -37.779, 175.847 -37.823, 175.839 -37.866, 175.825 -37.90...>
     >>> solution = solvis.InversionSolution.from_archive(filename)
-    >>> model = solution.model
-    >>> rupture_ids = FilterRuptureIds(model)\
+    >>> rupture_ids = FilterRuptureIds(solution)\
             .for_magnitude(min_mag=5.75, max_mag=6.25)\
             .for_polygon(ham50)
 
     >>> # ruptures on any of faults A, B, with magnitude and rupture rate limits
-    >>> rupture_ids = FilterRuptureIds(model)\
+    >>> rupture_ids = FilterRuptureIds(solution)\
     >>>    .for_parent_fault_names(['Alpine: Jacksons to Kaniere', 'Vernon 1' ])\
     >>>    .for_magnitude(7.0, 8.0)\
     >>>    .for_rupture_rate(1e-6, 1e-2)
 
     >>> # ruptures on fault A that do not involve fault B:
-    >>> rupture_ids = FilterRuptureIds(model)\
+    >>> rupture_ids = FilterRuptureIds(solution)\
     >>>    .for_parent_fault_names(['Alpine: Jacksons to Kaniere'])\
     >>>    .for_parent_fault_names(['Vernon 1'], join_prior='difference')
     ```

--- a/solvis/filter/rupture_id_filter.py
+++ b/solvis/filter/rupture_id_filter.py
@@ -305,5 +305,5 @@ class FilterRuptureIds(ChainableSetBase):
             df1 = self._solution.model.rupture_sections
 
         df2 = df1.join(df0, 'section', how='inner')
-        result = set(df2[index].unique())
+        result = set(df2[index].tolist())
         return self.new_chainable_set(result, self._solution, self._drop_zero_rates, join_prior=join_prior)

--- a/solvis/filter/subsection_id_filter.py
+++ b/solvis/filter/subsection_id_filter.py
@@ -2,18 +2,18 @@ r"""
 This module provides a class for filtering solution fault sections (subsections).
 
 Classes:
- FilterSubsectionIds: a filter for ruptures, returning qualifying rupture ids.
+ FilterSubsectionIds: a chainable filter for fault sections, returning qualifying fault section ids.
 
 Examples:
     ```py
     >>> ham50 = solvis.circle_polygon(50000, -37.78, 175.28)  # 50km radius around Hamilton
     <POLYGON ((175.849 -37.779, 175.847 -37.823, 175.839 -37.866, 175.825 -37.90...>
-    >>> sol = solvis.InversionSolution.from_archive(filename)
-    >>> rupture_ids = FilterRuptureIds(sol)\
+    >>> solution = solvis.InversionSolution.from_archive(filename)
+    >>> rupture_ids = FilterRuptureIds(solution)\
             .for_magnitude(min_mag=5.75, max_mag=6.25)\
             .for_polygon(ham50)
 
-    >>> subsection_ids = FilterSubsectionIds(sol)\
+    >>> subsection_ids = FilterSubsectionIds(solution)\
     >>>     .for_rupture_ids(rupture_ids)
     ```
 """

--- a/solvis/solution/typing.py
+++ b/solvis/solution/typing.py
@@ -284,3 +284,4 @@ class SetOperationEnum(Enum):
     UNION = 1
     INTERSECTION = 2
     DIFFERENCE = 3
+    SYMMETRIC_DIFFERENCE = 4

--- a/test/filter/test_filter_rupture_ids.py
+++ b/test/filter/test_filter_rupture_ids.py
@@ -73,6 +73,13 @@ def test_ruptures_for_polygon_intersecting(crustal_solution_fixture, filter_rupt
     ).issubset(rupture_ids)
 
 
+def test_ruptures_for_polygon_type(crustal_solution_fixture, filter_rupture_ids):
+    MRO = location_by_id('MRO')
+    poly = circle_polygon(1.5e5, MRO['latitude'], MRO['longitude'])  # 150km circle around MRO
+    rids = filter_rupture_ids.for_polygon(poly)
+    assert isinstance(list(rids)[0], int)
+
+
 def test_ruptures_for_polygons_join_iterable(crustal_solution_fixture, filter_rupture_ids):
     WLG = location_by_id('WLG')
     MRO = location_by_id('MRO')


### PR DESCRIPTION
 - closes #51
 - added symmetric difference
 - some small docstring fixes
 - also closes #57 with test. In an ideal world the typing for ChainableSet would support this. eg `-> ChainableSet[int]`
