### PR TITLE
refactor to remove *Protocol superclasses

### DIFF
--- a/solvis/fault_system_solution_helper.py
+++ b/solvis/fault_system_solution_helper.py
@@ -1,8 +1,6 @@
 """Provides a simple rupture grouping feature."""
 
-from typing import Dict, Iterator, List, Optional
-
-from solvis.solution.typing import InversionSolutionProtocol
+from typing import TYPE_CHECKING, Dict, Iterator, List, Optional
 
 """
 NAMES
@@ -12,10 +10,12 @@ NAMES
     - `named_fault` => Opensha:NamedFault => CFM: ??
     - `rupture`      => Opensha:Rupture => CFM: n/a
 """
+if TYPE_CHECKING:
+    from solvis import InversionSolution
 
 
 def build_rupture_groups(
-    solution: InversionSolutionProtocol, rupture_ids: Optional[List[int]] = None, min_overlap: float = 0.8
+    solution: 'InversionSolution', rupture_ids: Optional[List[int]] = None, min_overlap: float = 0.8
 ) -> Iterator[Dict]:
     """Group ruptures that are similar.
 

--- a/solvis/filter/parent_fault_id_filter.py
+++ b/solvis/filter/parent_fault_id_filter.py
@@ -25,13 +25,16 @@ Examples:
     ```
 """
 
-from typing import Iterable, Iterator, NamedTuple, Set, Union
+from typing import TYPE_CHECKING, Iterable, Iterator, NamedTuple, Set, Union
 
 import shapely.geometry
 
 from ..solution import named_fault
-from ..solution.typing import InversionSolutionProtocol, SetOperationEnum
+from ..solution.typing import SetOperationEnum
 from .chainable_set_base import ChainableSetBase
+
+if TYPE_CHECKING:
+    from solvis import InversionSolution
 
 
 class ParentFaultMapping(NamedTuple):
@@ -42,7 +45,7 @@ class ParentFaultMapping(NamedTuple):
 
 
 def parent_fault_name_id_mapping(
-    solution: InversionSolutionProtocol, parent_fault_ids: Iterable[int]
+    solution: 'InversionSolution', parent_fault_ids: Iterable[int]
 ) -> Iterator[ParentFaultMapping]:
     """For each unique parent_fault_id yield a ParentFaultMapping object.
 
@@ -93,7 +96,7 @@ class FilterParentFaultIds(ChainableSetBase):
         ```
     """
 
-    def __init__(self, solution: InversionSolutionProtocol):
+    def __init__(self, solution: 'InversionSolution'):
         """Instantiate a new filter.
 
         Args:

--- a/solvis/filter/subsection_id_filter.py
+++ b/solvis/filter/subsection_id_filter.py
@@ -18,19 +18,22 @@ Examples:
     ```
 """
 
-from typing import Iterable, Union
+from typing import TYPE_CHECKING, Iterable, Union
 
-from solvis.solution.typing import InversionSolutionProtocol, SetOperationEnum
+from solvis.solution.typing import SetOperationEnum
 
 from ..solution import named_fault
 from .chainable_set_base import ChainableSetBase
 from .parent_fault_id_filter import FilterParentFaultIds
 
+if TYPE_CHECKING:
+    from solvis import InversionSolution
+
 
 class FilterSubsectionIds(ChainableSetBase):
     """A helper class to filter subsections, returning qualifying section_ids."""
 
-    def __init__(self, solution: InversionSolutionProtocol):
+    def __init__(self, solution: 'InversionSolution'):
         """Instantiate a new filter.
 
         Args:

--- a/solvis/solution/fault_system_solution/fault_system_solution.py
+++ b/solvis/solution/fault_system_solution/fault_system_solution.py
@@ -173,6 +173,7 @@ class FaultSystemSolution(InversionSolution):
             solution.solution_file.fault_regime,
             solution.solution_file.average_slips.copy(),
         )
+
         fss_file._archive_path = solution.solution_file.archive_path
 
         new_fss = FaultSystemSolution(fss_file)

--- a/solvis/solution/fault_system_solution/fault_system_solution.py
+++ b/solvis/solution/fault_system_solution/fault_system_solution.py
@@ -19,33 +19,31 @@ import io
 import logging
 import zipfile
 from pathlib import Path
-from typing import Iterable, Optional, Union, cast
+from typing import TYPE_CHECKING, Iterable, Optional, Union, cast
 
 # import geopandas as gpd
 import nzshm_model as nm
 import pandas as pd
 
-from solvis.dochelper import inherit_docstrings
-
 from ..inversion_solution import InversionSolution
 
 # from ..solution_surfaces_builder import SolutionSurfacesBuilder
-from ..typing import BranchSolutionProtocol, InversionSolutionProtocol, ModelLogicTreeBranch
+from ..typing import ModelLogicTreeBranch
 from .fault_system_solution_file import FaultSystemSolutionFile
 from .fault_system_solution_model import FaultSystemSolutionModel
 
 log = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from ..inversion_solution import BranchInversionSolution
 
-@inherit_docstrings
+
 class FaultSystemSolution(InversionSolution):
     """A class that aggregates InversionSolution instances sharing a common OpenSHA RuptureSet.
 
     The class is largely interchangeable with InversionSolution, as only rupture rates
     are  affected by the aggregation.
     """
-
-    # Docstrings for most methods are found in the `InversionSolutionProtocol` class.
 
     def __init__(self, solution_file: Optional[FaultSystemSolutionFile] = None):
         self._solution_file: FaultSystemSolutionFile = solution_file or FaultSystemSolutionFile()
@@ -83,7 +81,7 @@ class FaultSystemSolution(InversionSolution):
         return FaultSystemSolution(new_solution_file)
 
     @staticmethod
-    def filter_solution(solution: 'InversionSolutionProtocol', rupture_ids: Iterable) -> 'FaultSystemSolution':
+    def filter_solution(solution: 'InversionSolution', rupture_ids: Iterable) -> 'FaultSystemSolution':
         # this method  is not actually used, and maybe deprecated in a future release
 
         solution = cast(FaultSystemSolution, solution)
@@ -136,7 +134,7 @@ class FaultSystemSolution(InversionSolution):
         return FaultSystemSolution(new_solution_file)
 
     @staticmethod
-    def new_solution(solution: BranchSolutionProtocol, composite_rates_df: pd.DataFrame) -> 'FaultSystemSolution':
+    def new_solution(solution: 'BranchInversionSolution', composite_rates_df: pd.DataFrame) -> 'FaultSystemSolution':
         # build a new fault system solution, taking solution template properties, and composite_rates_df
         composite_rates_df = composite_rates_df[composite_rates_df["Annual Rate"] > 0]
         composite_rates_df.insert(
@@ -207,7 +205,7 @@ class FaultSystemSolution(InversionSolution):
         return inversion_solution_id
 
     @staticmethod
-    def from_branch_solutions(solutions: Iterable[BranchSolutionProtocol]) -> 'FaultSystemSolution':
+    def from_branch_solutions(solutions: Iterable['BranchInversionSolution']) -> 'FaultSystemSolution':
 
         # combine the rupture rates from all solutions
         composite_rates_df = pd.DataFrame(columns=['Rupture Index'])  # , 'Magnitude'])

--- a/solvis/solution/fault_system_solution/fault_system_solution_file.py
+++ b/solvis/solution/fault_system_solution/fault_system_solution_file.py
@@ -64,12 +64,34 @@ class FaultSystemSolutionFile(InversionSolutionFile):
     ]
 
     def __init__(self) -> None:
+        """
+        Initializes a new FaultSystemSolutionFile instance.
+
+        Args:
+            self (FaultSystemSolutionFile): The instance to initialize.
+        """
         self._rates: Optional[pd.DataFrame] = None
         super().__init__()
 
     def set_props(
         self, composite_rates, aggregate_rates, ruptures, indices, fault_sections, fault_regime, average_slips
     ):
+        """
+        Sets the properties of the FaultSystemSolutionFile instance.
+
+        Args:
+            self (FaultSystemSolutionFile): The instance to set properties for.
+            composite_rates (pd.DataFrame): The composite rates dataframe.
+            aggregate_rates (pd.DataFrame): The aggregate rates dataframe.
+            ruptures (pd.DataFrame): The ruptures dataframe.
+            indices (pd.DataFrame): The indices dataframe.
+            fault_sections (pd.DataFrame): The fault sections dataframe.
+            fault_regime (pd.DataFrame): The fault regime dataframe.
+            average_slips (pd.DataFrame): The average slips dataframe.
+
+        Returns:
+            None
+        """
         self._composite_rates = composite_rates
         self._aggregate_rates = aggregate_rates
 
@@ -77,11 +99,20 @@ class FaultSystemSolutionFile(InversionSolutionFile):
         rates = aggregate_rates.drop(columns=['rate_max', 'rate_min', 'rate_count', 'fault_system']).rename(
             columns={"rate_weighted_mean": "Annual Rate"}
         )
-        # print(self.aggregate_rates.info())
-        # assert 0
         super().set_props(rates, ruptures, indices, fault_sections, average_slips)
 
     def _write_dataframes(self, zip_archive: zipfile.ZipFile, reindex: bool = False):
+        """
+        Writes the dataframes to a zip archive.
+
+        Args:
+            self (FaultSystemSolutionFile): The instance to write dataframes for.
+            zip_archive (zipfile.ZipFile): The zip archive to write to.
+            reindex (bool): Whether to reindex the dataframes before writing. Defaults to False.
+
+        Returns:
+            None
+        """
         data_to_zip_direct(zip_archive, self.composite_rates.to_csv(index=reindex), self.COMPOSITE_RATES_PATH)
         data_to_zip_direct(zip_archive, self.aggregate_rates.to_csv(index=reindex), self.AGGREGATE_RATES_PATH)
         if self._fast_indices is not None:
@@ -95,8 +126,13 @@ class FaultSystemSolutionFile(InversionSolutionFile):
         super().to_archive(archive_path, base_archive_path, compat=False)
 
     @property
-    def composite_rates(self) -> gpd.GeoDataFrame:
-        # dtypes: defaultdict = defaultdict(pd.Float32Dtype)
+    def composite_rates(self) -> pd.DataFrame:
+        """
+        Returns the composite rates dataframe.
+
+        Returns:
+            pd.DataFrame: The composite rates dataframe.
+        """
         if self._composite_rates is None:
             dtypes = {}
             dtypes["Rupture Index"] = 'UInt32'  # pd.UInt32Dtype()
@@ -107,7 +143,12 @@ class FaultSystemSolutionFile(InversionSolutionFile):
 
     @property
     def aggregate_rates(self) -> gpd.GeoDataFrame:
-        # dtypes: defaultdict = defaultdict(np.float32)
+        """
+        Returns the aggregate rates GeoDataFrame.
+
+        Returns:
+            gpd.GeoDataFrame: The aggregate rates GeoDataFrame.
+        """
         if self._aggregate_rates is None:
             dtypes = {}
             dtypes["Rupture Index"] = 'UInt32'  # pd.UInt32Dtype()
@@ -118,14 +159,32 @@ class FaultSystemSolutionFile(InversionSolutionFile):
         return df0
 
     @property
-    @cache
     def rupture_rates(self) -> 'DataFrame[RuptureRateSchema]':
+        """
+        Returns a GeoDataFrame containing the rupture rates.
+
+        This property returns a pandas DataFrame with a schema of `RuptureRateSchema`, representing the
+        rupture rates. The data is loaded from the `aggregate_rates` GeoDataFrame, ensuring that
+        it adheres to the specified schema.
+
+        Returns:
+            DataFrame[RuptureRateSchema]: A GeoDataFrame containing the rupture rates.
+        """
         return cast('DataFrame[RuptureRateSchema]', self.aggregate_rates)
 
     @property
+    @cache
     def fast_indices(self) -> gpd.GeoDataFrame:
-        # dtypes: defaultdict = defaultdict(pd.UInt32Dtype)
+        """
+        Retrieves the fast indices as a GeoDataFrame.
+
+        The `fast_indices` property returns a pandas DataFrame containing
+        index data for ruptures, indexed by 'sections'. This data is read from the CSV file specified by
+        `FAST_INDICES_PATH`, applying specific data types to columns.
+
+        Returns:
+            gpd.GeoDataFrame: A GeoDataFrame containing the fast indices.
+        """
         dtypes = {}
-        dtypes["ruptures"] = 'UInt32'  # pd.UInt32Dtype()
         dtypes["sections"] = 'UInt32'  # pd.UInt32Dtype()
-        return self._dataframe_from_csv(self._fast_indices, self.FAST_INDICES_PATH, dtypes)
+        return self._dataframe_from_csv(self.FAST_INDICES_PATH, dtypes)

--- a/solvis/solution/fault_system_solution/fault_system_solution_file.py
+++ b/solvis/solution/fault_system_solution/fault_system_solution_file.py
@@ -74,7 +74,7 @@ class FaultSystemSolutionFile(InversionSolutionFile):
         self._aggregate_rates = aggregate_rates
 
         # Now we need a rates table, structured correctly, with weights from the aggregate_rates
-        rates = self.aggregate_rates.drop(columns=['rate_max', 'rate_min', 'rate_count', 'fault_system']).rename(
+        rates = aggregate_rates.drop(columns=['rate_max', 'rate_min', 'rate_count', 'fault_system']).rename(
             columns={"rate_weighted_mean": "Annual Rate"}
         )
         # print(self.aggregate_rates.info())
@@ -97,21 +97,25 @@ class FaultSystemSolutionFile(InversionSolutionFile):
     @property
     def composite_rates(self) -> gpd.GeoDataFrame:
         # dtypes: defaultdict = defaultdict(pd.Float32Dtype)
-        dtypes = {}
-        dtypes["Rupture Index"] = 'UInt32'  # pd.UInt32Dtype()
-        dtypes["fault_system"] = 'category'  # pd.CategoricalDtype()
-        df = self._dataframe_from_csv(self._composite_rates, self.COMPOSITE_RATES_PATH, dtypes)
-        return df.set_index(["solution_id", "Rupture Index"], drop=False)
+        if self._composite_rates is None:
+            dtypes = {}
+            dtypes["Rupture Index"] = 'UInt32'  # pd.UInt32Dtype()
+            dtypes["fault_system"] = 'category'  # pd.CategoricalDtype()
+            self._composite_rates = self._dataframe_from_csv(self.COMPOSITE_RATES_PATH, dtypes)
+        df0 = self._composite_rates.set_index(["solution_id", "Rupture Index"], drop=False)
+        return df0
 
     @property
     def aggregate_rates(self) -> gpd.GeoDataFrame:
         # dtypes: defaultdict = defaultdict(np.float32)
-        dtypes = {}
-        dtypes["Rupture Index"] = 'UInt32'  # pd.UInt32Dtype()
-        dtypes["fault_system"] = 'category'  # pd.CategoricalDtype()
-        dtypes["Annual Rate"] = 'Float32'  # pd.Float32Dtype()
-        df = self._dataframe_from_csv(self._aggregate_rates, self.AGGREGATE_RATES_PATH, dtypes)
-        return df.set_index(["fault_system", "Rupture Index"], drop=False)
+        if self._aggregate_rates is None:
+            dtypes = {}
+            dtypes["Rupture Index"] = 'UInt32'  # pd.UInt32Dtype()
+            dtypes["fault_system"] = 'category'  # pd.CategoricalDtype()
+            dtypes["Annual Rate"] = 'Float32'  # pd.Float32Dtype()
+            self._aggregate_rates = self._dataframe_from_csv(self.AGGREGATE_RATES_PATH, dtypes)
+        df0 = self._aggregate_rates.set_index(["fault_system", "Rupture Index"], drop=False)
+        return df0
 
     @property
     @cache

--- a/solvis/solution/fault_system_solution/fault_system_solution_file.py
+++ b/solvis/solution/fault_system_solution/fault_system_solution_file.py
@@ -6,7 +6,8 @@ See notes about FaultSystemSolution and OpenSHA InversionSolution archive format
 
 import logging
 import zipfile
-from typing import TYPE_CHECKING, Optional
+from functools import cache
+from typing import TYPE_CHECKING, Optional, cast
 
 import geopandas as gpd
 import pandas as pd
@@ -18,7 +19,7 @@ from ..inversion_solution import InversionSolutionFile, data_to_zip_direct
 if TYPE_CHECKING:
     from pandera.typing import DataFrame
 
-    from .dataframe_models import RuptureRateSchema
+    from ..dataframe_models import RuptureRateSchema
 
 log = logging.getLogger(__name__)
 
@@ -113,8 +114,9 @@ class FaultSystemSolutionFile(InversionSolutionFile):
         return df.set_index(["fault_system", "Rupture Index"], drop=False)
 
     @property
+    @cache
     def rupture_rates(self) -> 'DataFrame[RuptureRateSchema]':
-        return self.aggregate_rates
+        return cast('DataFrame[RuptureRateSchema]', self.aggregate_rates)
 
     @property
     def fast_indices(self) -> gpd.GeoDataFrame:

--- a/solvis/solution/fault_system_solution/fault_system_solution_model.py
+++ b/solvis/solution/fault_system_solution/fault_system_solution_model.py
@@ -10,8 +10,6 @@ from typing import TYPE_CHECKING, Optional, cast
 
 from pandera.typing import DataFrame
 
-from solvis.dochelper import inherit_docstrings
-
 from ..dataframe_models import RuptureSectionSchema
 from ..inversion_solution import InversionSolutionModel
 from .fault_system_solution_file import FaultSystemSolutionFile
@@ -24,8 +22,9 @@ if TYPE_CHECKING:
     # from numpy.typing import NDArray
     import pandas as pd
 
+    from solvis.solution import dataframe_models
 
-@inherit_docstrings
+
 class FaultSystemSolutionModel(InversionSolutionModel):
     """For analysis of FaultSystemSolutions."""
 
@@ -33,10 +32,6 @@ class FaultSystemSolutionModel(InversionSolutionModel):
         self._fast_indices: Optional[pd.DataFrame] = None
         self._solution_file: FaultSystemSolutionFile = solution_file
         super().__init__(solution_file)
-
-    # @property
-    # def indices(self):
-    #     return self._solution_file.indices
 
     @property
     def composite_rates(self):
@@ -58,10 +53,7 @@ class FaultSystemSolutionModel(InversionSolutionModel):
                 # TODO: this smells bad ....
                 self._solution_file._fast_indices = self._fast_indices
 
-        if self._rupture_sections is None:
-            self._rupture_sections = self._fast_indices
-
-        return cast(DataFrame[RuptureSectionSchema], self._rupture_sections)
+        return cast('DataFrame[dataframe_models.RuptureSectionSchema]', self._fast_indices)
 
     def enable_fast_indices(self) -> bool:
         """Ensure that the fast_indices dataframe is available."""

--- a/solvis/solution/inversion_solution/inversion_solution_file.py
+++ b/solvis/solution/inversion_solution/inversion_solution_file.py
@@ -276,7 +276,6 @@ class InversionSolutionFile:
         return get_regime()
 
     @property
-    @cache
     def rupture_rates(self) -> 'DataFrame[RuptureRateSchema]':
         """
         Get the rupture rates from the archive.
@@ -337,7 +336,6 @@ class InversionSolutionFile:
         return self._average_slips
 
     @property
-    @cache
     def section_target_slip_rates(self) -> gpd.GeoDataFrame:
         """
         Get the section target slip rates from the archive.

--- a/solvis/solution/inversion_solution/inversion_solution_model.py
+++ b/solvis/solution/inversion_solution/inversion_solution_model.py
@@ -7,12 +7,11 @@ from the raw dataframes available via the `InversionSolutionFile` class.
 
 import logging
 import time
+from functools import cache
 from typing import TYPE_CHECKING, List, Optional, cast
 
 import geopandas as gpd
 import pandas as pd
-
-from solvis.solution.typing import InversionSolutionModelProtocol
 
 from .inversion_solution_file import InversionSolutionFile
 
@@ -24,10 +23,16 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class InversionSolutionModel(InversionSolutionModelProtocol):
+class InversionSolutionModel:
     """helper methods for analysis of InversionSolutionProtocol subtypes."""
 
     def __init__(self, solution_file: InversionSolutionFile) -> None:
+        """
+        Initialize the `InversionSolutionModel` class.
+
+        Args:
+            solution_file (InversionSolutionFile): The inversion solution file to use.
+        """
         self._solution_file = solution_file
         self._rs_with_rupture_rates: Optional[pd.DataFrame] = None
         self._ruptures_with_rupture_rates: Optional[pd.DataFrame] = None
@@ -38,13 +43,19 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
 
     @property
     def solution_file(self) -> InversionSolutionFile:
+        """
+        Get the inversion solution file used by this model.
+
+        Returns:
+            InversionSolutionFile: The inversion solution file.
+        """
         return self._solution_file
 
     def rate_column_name(self) -> str:
-        """Get the appropriate rate_column name.
+        """Get the appropriate rate column name.
 
         Returns:
-            rate_column: "Annual Rate" or rate_weighted_mean"
+            str: "Annual Rate" or "rate_weighted_mean"
         """
         return (
             "Annual Rate" if self._solution_file.__class__.__name__ == "InversionSolutionFile" else "rate_weighted_mean"
@@ -56,16 +67,19 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
         Calculate and cache the permutations of rupture_id and section_id.
 
         Returns:
-            pd.DataFrame: a pandas dataframe
+            pd.DataFrame: A pandas dataframe conforming to the RuptureSectionSchema.
         """
-        if self._rupture_sections is not None:
-            return cast('DataFrame[dataframe_models.RuptureSectionSchema]', self._rupture_sections)
+        rupture_sections = self.build_rupture_sections()
+        return cast('DataFrame[dataframe_models.RuptureSectionSchema]', rupture_sections)
 
-        self._rupture_sections = self.build_rupture_sections()
-        return cast('DataFrame[dataframe_models.RuptureSectionSchema]', self._rupture_sections)
-
+    @cache
     def build_rupture_sections(self) -> 'DataFrame[dataframe_models.RuptureSectionSchema]':
+        """
+        Build the rupture sections dataframe.
 
+        Returns:
+            pd.DataFrame: A pandas dataframe conforming to the RuptureSectionSchema.
+        """
         tic = time.perf_counter()
 
         rs = self.solution_file.indices  # _dataframe_from_csv(self._rupture_sections, 'ruptures/indices.csv').copy()
@@ -89,23 +103,18 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
         return cast('DataFrame[dataframe_models.RuptureSectionSchema]', df2)
 
     @property
+    @cache
     def fault_sections_with_rupture_rates(self) -> 'DataFrame[dataframe_models.FaultSectionRuptureRateSchema]':
         """
-        Calculate and cache the fault sections and their rupture rates.
+        Get the fault sections with rupture rates.
 
         Returns:
-            a gpd.GeoDataFrame
+            pd.DataFrame: A pandas dataframe conforming to the FaultSectionRuptureRateSchema.
         """
-        # assert 0
-        if self._fs_with_rates is not None:
-            print(self._fs_with_rates.columns)
-            # assert 0
-            return cast('DataFrame[dataframe_models.FaultSectionRuptureRateSchema]', self._fs_with_rates)
-
         tic = time.perf_counter()
         print(self.rs_with_rupture_rates)
         assert self.rs_with_rupture_rates is not None
-        self._fs_with_rates = self.rs_with_rupture_rates.join(self.solution_file.fault_sections, 'section', how='inner')
+        fs_with_rates = self.rs_with_rupture_rates.join(self.solution_file.fault_sections, 'section', how='inner')
         toc = time.perf_counter()
         log.debug(
             (
@@ -114,16 +123,20 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
             )
             % (toc - tic)
         )
-
-        # self._fs_with_rates = self.fault_sections.join(self.ruptures_with_rupture_rates,
-        #     on=self.fault_sections["Rupture Index"] )
-        return cast('DataFrame[dataframe_models.FaultSectionRuptureRateSchema]', self._fs_with_rates)
+        return cast('DataFrame[dataframe_models.FaultSectionRuptureRateSchema]', fs_with_rates)
 
     @property
+    @cache
     def parent_fault_names(self) -> List[str]:
+        """Get a sorted list of unique parent fault names.
+
+        Returns:
+            List[str]: A list of unique parent fault names.
+        """
         return sorted(self.solution_file.fault_sections.ParentName.unique())
 
     @property
+    @cache
     def fault_sections_with_solution_slip_rates(self) -> 'DataFrame[dataframe_models.FaultSectionWithSolutionSlipRate]':
         """Calculate and cache fault sections and their solution slip rates.
 
@@ -132,14 +145,11 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
         Returns:
             a gpd.GeoDataFrame
         """
-        if self._fs_with_soln_rates is not None:
-            return cast('DataFrame[dataframe_models.FaultSectionWithSolutionSlipRate]', self._fs_with_soln_rates)
-
         tic = time.perf_counter()
-        self._fs_with_soln_rates = self._get_soln_rates()
+        fs_with_soln_rates = self._get_soln_rates()
         toc = time.perf_counter()
         log.debug('fault_sections_with_soilution_rates: time to calculate solution rates: %2.3f seconds' % (toc - tic))
-        return cast('DataFrame[dataframe_models.FaultSectionWithSolutionSlipRate]', self._fs_with_soln_rates)
+        return cast('DataFrame[dataframe_models.FaultSectionWithSolutionSlipRate]', fs_with_soln_rates)
 
     def _get_soln_rates(self) -> 'DataFrame[dataframe_models.FaultSectionWithSolutionSlipRate]':
         """Get a dataframe joining ruptures and rupture_rates.
@@ -163,24 +173,20 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
         return cast('DataFrame[dataframe_models.FaultSectionWithSolutionSlipRate]', fault_sections_wr)
 
     @property
+    @cache
     def rs_with_rupture_rates(self) -> 'DataFrame[dataframe_models.RuptureSectionsWithRuptureRatesSchema]':
-        """Get a dataframe joining rupture_sections and rupture_rates.
+        """
+        Get the rupture sections with rupture rates.
 
         Returns:
-            a gpd.GeoDataFrame
+            pd.DataFrame: A pandas dataframe conforming to the RuptureSectionsWithRuptureRatesSchema.
         """
-        if self._rs_with_rupture_rates is not None:
-            return cast(
-                'DataFrame[dataframe_models.RuptureSectionsWithRuptureRatesSchema]', self._rs_with_rupture_rates
-            )
-
         tic = time.perf_counter()
         # df_rupt_rate = self.ruptures.join(self.rupture_rates.drop(self.rupture_rates.iloc[:, :1], axis=1))
-        self._rs_with_rupture_rates = self.ruptures_with_rupture_rates.join(
+        rs_with_rupture_rates = self.ruptures_with_rupture_rates.join(
             self.rupture_sections.set_index("rupture"),
             on=self.ruptures_with_rupture_rates["Rupture Index"],  # type: ignore
         )
-
         toc = time.perf_counter()
         log.info(
             (
@@ -189,28 +195,27 @@ class InversionSolutionModel(InversionSolutionModelProtocol):
             )
             % (toc - tic)
         )
-        return cast('DataFrame[dataframe_models.RuptureSectionsWithRuptureRatesSchema]', self._rs_with_rupture_rates)
+        return cast('DataFrame[dataframe_models.RuptureSectionsWithRuptureRatesSchema]', rs_with_rupture_rates)
 
     @property
+    @cache
     def ruptures_with_rupture_rates(self) -> 'DataFrame[dataframe_models.RupturesWithRuptureRatesSchema]':
-        """Get a dataframe joining ruptures and rupture_rates.
+        """
+        Get the ruptures with rupture rates.
 
         Returns:
-            a gpd.GeoDataFrame
+            pd.DataFrame: A pandas dataframe conforming to the RupturesWithRuptureRatesSchema.
         """
-        if self._ruptures_with_rupture_rates is not None:
-            return cast('DataFrame[dataframe_models.RupturesWithRuptureRatesSchema]', self._ruptures_with_rupture_rates)
-
         tic = time.perf_counter()
         # print(self.rupture_rates.drop(self.rupture_rates.iloc[:, :1], axis=1))
-        self._ruptures_with_rupture_rates = self.solution_file.rupture_rates.join(
+        ruptures_with_rupture_rates = self.solution_file.rupture_rates.join(
             self.solution_file.ruptures.drop(columns="Rupture Index"),
             on=self.solution_file.rupture_rates["Rupture Index"],  # type: ignore
         )
-        if 'key_0' in self._ruptures_with_rupture_rates.columns:  # pragma: no cover (can this be dropped?)
-            self._ruptures_with_rupture_rates.drop(columns=['key_0'], inplace=True)
+        if 'key_0' in ruptures_with_rupture_rates.columns:  # pragma: no cover (can this be dropped?)
+            ruptures_with_rupture_rates.drop(columns=['key_0'], inplace=True)
         toc = time.perf_counter()
         log.debug(
             'ruptures_with_rupture_rates(): time to load rates and join with ruptures: %2.3f seconds' % (toc - tic)
         )
-        return cast('DataFrame[dataframe_models.RupturesWithRuptureRatesSchema]', self._ruptures_with_rupture_rates)
+        return cast('DataFrame[dataframe_models.RupturesWithRuptureRatesSchema]', ruptures_with_rupture_rates)

--- a/solvis/solution/solution_participation.py
+++ b/solvis/solution/solution_participation.py
@@ -9,14 +9,15 @@ import pandas as pd
 from solvis.filter import FilterParentFaultIds, FilterSubsectionIds
 from solvis.solution import named_fault
 
-from .typing import InversionSolutionProtocol
-
 if TYPE_CHECKING:
     from pandera.typing import DataFrame
 
     from solvis.solution import dataframe_models
 
 log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from solvis import InversionSolution
 
 
 class SolutionParticipation:
@@ -40,7 +41,7 @@ class SolutionParticipation:
         named_fault_participation_rates: get rates for named faults
     """
 
-    def __init__(self, solution: InversionSolutionProtocol):
+    def __init__(self, solution: 'InversionSolution'):
         """Instantiate a new instance.
 
         Args:

--- a/solvis/solution/typing.py
+++ b/solvis/solution/typing.py
@@ -10,100 +10,14 @@ Classes:
 
 """
 
-import io
-import zipfile
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Iterable, List, Mapping, Optional, Protocol, Union
+from typing import TYPE_CHECKING, Any, List, Mapping, Optional, Protocol, Union
 
 import geopandas as gpd
 
 if TYPE_CHECKING:
-    # from numpy.typing import NDArray
-    from pandera.typing import DataFrame
-
-    from .dataframe_models import FaultSectionSchema, RuptureRateSchema
-
-
-class InversionSolutionFileProtocol(Protocol):
-    """Type for InversionSolutionFile."""
-
-    FAULTS_PATH: Union[Path, str] = ''
-
-    @property
-    def archive_path(self) -> Optional[Path]:
-        """The path of the archive (if any).
-
-        Returns:
-            filepath: the file system path.
-        """
-        raise NotImplementedError()
-
-    @property
-    def fault_regime(self) -> str:
-        """The fault regime as defined in the opensha logic_tree_branch data file.
-
-        Returns:
-            regime: `CRUSTAL` or `SUBDUCTION` respectively.
-        """
-        raise NotImplementedError()
-
-    @property
-    def logic_tree_branch(self) -> list:
-        """Values from the opensha `logic_tree_branch` data file.
-
-        Returns:
-            list of value objects
-        """
-
-    @property
-    def average_slips(self) -> gpd.GeoDataFrame:
-        """The average slips for each rupture."""
-        raise NotImplementedError()
-
-    @property
-    def section_target_slip_rates(self) -> gpd.GeoDataFrame:
-        """The inversion target slip rates for each rupture."""
-        raise NotImplementedError()
-
-    @property
-    def indices(self) -> gpd.GeoDataFrame:
-        """The fault sections involved in each rupture."""
-        raise NotImplementedError()
-
-    @property
-    def archive(self) -> Optional[zipfile.ZipFile]:
-        """The archive instance."""
-        raise NotImplementedError()
-
-    @property
-    def fault_sections(self) -> 'DataFrame[FaultSectionSchema]':
-        """Get the fault sections, with target slip rates from inversion.
-
-        Returns:
-            pd.DataFrame: participation rates dataframe
-        """
-        raise NotImplementedError()
-
-    @property
-    def ruptures(self) -> gpd.GeoDataFrame:
-        """A dataframe containing ruptures.
-
-        this is internal list only
-
-        Returns:
-          dataframe: a ruptures dataframe
-        """
-        raise NotImplementedError()
-
-    @property
-    def rupture_rates(self) -> 'DataFrame[RuptureRateSchema]':
-        """A dataframe containing ruptures and their rates.
-
-        Returns:
-          dataframe: a [rupture rates][solvis.solution.dataframe_models.RuptureRateSchema] dataframe
-        """
-        raise NotImplementedError()
+    from inversion_solution import InversionSolution
 
 
 class AggregateSolutionFileProtocol(Protocol):
@@ -115,138 +29,10 @@ class AggregateSolutionFileProtocol(Protocol):
         raise NotImplementedError()
 
 
-class InversionSolutionModelProtocol(Protocol):
-    """Type for InversionSolutionModel."""
-
-    @property
-    def fault_sections_with_rupture_rates(self) -> gpd.GeoDataFrame:
-        """Get the fault sections and their rupture rates."""
-        raise NotImplementedError()
-
-    @property
-    def rupture_sections(self) -> gpd.GeoDataFrame:
-        """The rupture sections for each rupture."""
-        raise NotImplementedError()
-
-    def rate_column_name(self) -> str:
-        """The name of the rate_column returned in dataframes."""
-        raise NotImplementedError()
-
-    @property
-    def parent_fault_names(self) -> List[str]:
-        """The parent_fault_names."""
-        raise NotImplementedError()
-
-    @property
-    def rs_with_rupture_rates(self) -> gpd.GeoDataFrame:
-        """The event rate for each rupture section."""
-        raise NotImplementedError()
-
-    @property
-    def ruptures_with_rupture_rates(self) -> gpd.GeoDataFrame:
-        """The event rate for each rupture."""
-        raise NotImplementedError()
-
-
-class InversionSolutionProtocol(Protocol):
-    """Type for InversionSolution."""
-
-    @staticmethod
-    def from_archive(instance_or_path: Union[Path, str, io.BytesIO]) -> 'InversionSolutionProtocol':
-        """Read and return a solution from an archive file or byte-stream.
-
-        Archive validity is checked with the presence of a `ruptures/indices.csv` file.
-
-        Args:
-            instance_or_path: a Path object, filename or in-memory binary IO stream
-
-        Returns:
-            A solution instance.
-        """
-        raise NotImplementedError()
-
-    @staticmethod
-    def filter_solution(
-        solution: 'InversionSolutionProtocol', rupture_ids: Iterable[int]
-    ) -> 'InversionSolutionProtocol':
-        """
-        Filter solution by a subset of its rupture IDs.
-
-        This is a utility method primarily for producing test fixtures.
-
-        Args:
-            solution: a solution instance.
-            rupture_ids: a sequence of rupture ids.
-
-        Returns:
-            A new solution instance.
-        """
-        raise NotImplementedError()
-
-    def to_archive(self, archive_path, base_archive_path=None, compat=False):
-        """Write the current solution to a new zip archive.
-
-        Optionally cloning data from a base archive.
-
-        In non-compatible mode (the default) rupture ids may not be a contiguous, 0-based sequence,
-        so the archive will not be suitable for use with opensha. Compatible mode will reindex rupture tables,
-        so that the original rutpure ids are lost.
-
-        Args:
-            archive_path: path or buffrer to write.
-            base_archive_path: path to an InversionSolution archive to clone data from.
-            compat: if True reindex the dataframes so that the archive remains compatible with opensha.
-        """
-        raise NotImplementedError()
-
-    @property
-    def model(self) -> 'InversionSolutionModelProtocol':
-        """The pandas dataframes API model of the solution.
-
-        Returns:
-            model: an instance of type InversionSolutionModelProtocol
-        """
-        raise NotImplementedError()
-
-    @property
-    def solution_file(self) -> 'InversionSolutionFileProtocol':
-        """The file protocol instance for the solution.
-
-        Returns:
-            instance: an instance of type InversionSolutionFileProtocol
-        """
-        raise NotImplementedError()
-
-    @property
-    def fault_regime(self) -> str:
-        """Get the fault regime label."""
-
-    def rupture_surface(self, rupture_id: int) -> gpd.GeoDataFrame:
-        """
-        Calculate the geometry of the rupture surface projected onto the earth surface.
-
-        Args:
-            rupture_id: ID of the rupture
-
-        Returns:
-            a gpd.GeoDataFrame
-        """
-        raise NotImplementedError()
-
-    def fault_surfaces(self) -> gpd.GeoDataFrame:
-        """
-        Calculate the geometry of the solution fault surfaces projected onto the earth surface.
-
-        Returns:
-            a gpd.GeoDataFrame
-        """
-        raise NotImplementedError()
-
-
 class CompositeSolutionProtocol(Protocol):
     """Type for CompositeSolution."""
 
-    _solutions: Mapping[str, InversionSolutionProtocol] = {}
+    _solutions: Mapping[str, 'InversionSolution'] = {}
     _archive_path: Optional[Path]
 
     def rupture_surface(self, fault_system: str, rupture_id: int) -> gpd.GeoDataFrame:
@@ -268,14 +54,6 @@ class ModelLogicTreeBranch(Protocol):
     distributed_nrml_id: Union[str, None] = ""
     inversion_solution_id: Union[str, None] = ""
     inversion_solution_type: Union[str, None] = ""
-
-
-class BranchSolutionProtocol(InversionSolutionProtocol):
-    """Type for BranchSolution maybe reduncant?"""
-
-    fault_system: Union[str, None] = ""
-    rupture_set_id: Union[str, None] = ""
-    branch: ModelLogicTreeBranch
 
 
 class SetOperationEnum(Enum):

--- a/test/test_fault_system_solution.py
+++ b/test/test_fault_system_solution.py
@@ -112,6 +112,15 @@ class TestSmallDataFrames(object):
         sol = puysegur_small_fss_fixture
         assert sol.solution_file.rupture_rates.shape == (7, RATE_COLUMNS_A)  # no 0 rates
 
+    def test_solution_file_rupture_sections(self, crustal_small_fss_fixture):
+        fss = crustal_small_fss_fixture
+        assert fss.model.enable_fast_indices()
+
+        df0 = fss.model.rupture_sections
+        print(df0.info())
+        assert df0.rupture.dtype == 'int64'
+        assert df0.section.dtype == pd.Int32Dtype()
+
     def test_rates_no_missing_aggregates(self, puysegur_small_fss_fixture):
         sol = puysegur_small_fss_fixture
         print(sol.solution_file.rupture_rates.info())

--- a/test/test_inversion_solution.py
+++ b/test/test_inversion_solution.py
@@ -6,11 +6,9 @@ import pathlib
 
 import pandas as pd
 import pytest
-from nzshm_common.location.location import location_by_id
-from pytest import approx, raises
+from pytest import approx
 
-from solvis import InversionSolution, circle_polygon
-from solvis.solution.typing import SetOperationEnum
+from solvis import InversionSolution
 
 folder = pathlib.PurePath(os.path.realpath(__file__)).parent
 
@@ -34,7 +32,6 @@ class TestInversionSolution(object):
         assert isinstance(sol, InversionSolution)
         assert sol.fault_regime == 'CRUSTAL'
         assert sol.solution_file.logic_tree_branch[0]['value']['enumName'] == "CRUSTAL"
-
         assert sol.solution_file.rupture_rates["Annual Rate"].dtype == pd.Float32Dtype()
         # assert sol.indices["Num Sections"].dtype == pd.UInt16Dtype()
         # assert sol.indices["# 1"].dtype == pd.UInt16Dtype()
@@ -54,118 +51,6 @@ class TestInversionSolution(object):
         assert sol.fault_regime == 'CRUSTAL'
         assert sol.solution_file.logic_tree_branch[0]['value']['enumName'] == "CRUSTAL"
 
-    # def test_load_subduction_from_archive(self, puysegur_fixture):
-    #     sol = puysegur_fixture
-    #     assert isinstance(sol, InversionSolution)
-    #     assert sol.fault_regime == 'SUBDUCTION'
-
-    @pytest.mark.skip('Deprecated')
-    def test_get_rupture_ids_intersecting_crustal(self, crustal_solution_fixture):
-        sol = crustal_solution_fixture
-
-        WLG = location_by_id('WLG')
-        # polygon = circle_polygon(5e5, -38.662334, 178.017654)
-        polygon = circle_polygon(1e5, WLG['latitude'], WLG['longitude'])  # 100km circle around WLG
-
-        ruptures = sol.model.get_rupture_ids_intersecting(polygon)
-        all_rupture_ids = list(sol.solution_file.ruptures.index)
-
-        assert len(sol.solution_file.ruptures) > len(ruptures)
-        assert set(all_rupture_ids).issuperset(set(ruptures))
-
-    @pytest.mark.skip('Deprecated')
-    def test_get_rupture_ids_for_parent_fault(self, crustal_solution_fixture):
-        model = crustal_solution_fixture.model
-
-        pf1_ids = set(model.get_rupture_ids_for_parent_fault("Alpine Kaniere to Springs Junction"))
-        pf2_ids = set(model.get_rupture_ids_for_parent_fault("Alpine Jacksons to Kaniere"))
-        print(list(pf1_ids))
-
-        assert pf1_ids is not pf2_ids, "Should return different rupture ID sets"
-        assert len(pf1_ids) is not len(pf2_ids), "Sets should have different lengths"
-        assert len(pf1_ids.intersection(pf2_ids)) > 0, "Sets are expected to overlap"
-
-    @pytest.mark.skip('Deprecated')
-    def test_get_rupture_ids_for_fault_names(self, crustal_solution_fixture):
-        model = crustal_solution_fixture.model
-
-        PARENT_FAULT_1 = "Alpine Jacksons to Kaniere"
-        PARENT_FAULT_2 = "Alpine Kaniere to Springs Junction"
-        PF1_IDS = set(model.get_rupture_ids_for_parent_fault(PARENT_FAULT_1))
-        PF2_IDS = set(model.get_rupture_ids_for_parent_fault(PARENT_FAULT_2))
-
-        # Ensure we get the same results as when joining sets manually.
-
-        rupture_ids_union = model.get_rupture_ids_for_fault_names(
-            corupture_fault_names=[PARENT_FAULT_1, PARENT_FAULT_2],
-            fault_join_type=SetOperationEnum.UNION,
-        )
-        assert len(rupture_ids_union) == len(PF1_IDS.union(PF2_IDS))
-
-        rupture_ids_intersection = model.get_rupture_ids_for_fault_names(
-            corupture_fault_names=[PARENT_FAULT_1, PARENT_FAULT_2],
-            fault_join_type=SetOperationEnum.INTERSECTION,
-        )
-
-        assert len(rupture_ids_intersection) == len(PF1_IDS.intersection(PF2_IDS))
-
-        with raises(ValueError):
-            model.get_rupture_ids_for_fault_names(
-                corupture_fault_names=[PARENT_FAULT_1, PARENT_FAULT_2],
-                fault_join_type=SetOperationEnum.DIFFERENCE,
-            )
-
-    @pytest.mark.skip('Deprecated')
-    def test_get_rupture_ids_for_location_radius(self, crustal_solution_fixture):
-        sol = crustal_solution_fixture.model
-
-        def _rupture_ids_for_location(location_id: str, radius_km: int = 100):
-            """Helper: ruptures in polygon around location."""
-            loc = location_by_id(location_id)
-            loc_polygon = circle_polygon(radius_km * 1000, loc["latitude"], loc["longitude"])
-            rupids = sol.get_rupture_ids_intersecting(loc_polygon)
-            return rupids
-
-        ruptures_wlg = _rupture_ids_for_location("WLG")
-        ruptures_bhe = _rupture_ids_for_location("BHE")
-        # All WLG results should also in BHE set for this fixture
-        expected_intersection_ruptures = set(ruptures_wlg).intersection(ruptures_bhe)
-        expected_union_ruptures = set(ruptures_wlg).union(ruptures_bhe)
-        expected_diff_ruptures = set(ruptures_wlg).difference(ruptures_bhe)
-
-        # Pre-checks on assumptions
-        assert len(ruptures_wlg) == len(expected_intersection_ruptures)
-        assert len(ruptures_bhe) == len(expected_union_ruptures)
-
-        wlg_rupture_ids = sol.get_rupture_ids_for_location_radius(
-            location_ids=["WLG"],
-            radius_km=100,
-            location_join_type=SetOperationEnum.INTERSECTION,
-        )
-        assert len(wlg_rupture_ids) == len(ruptures_wlg)
-
-        intersection_rupture_ids = sol.get_rupture_ids_for_location_radius(
-            location_ids=["WLG", "BHE"],
-            radius_km=100,
-            location_join_type=SetOperationEnum.INTERSECTION,
-        )
-        assert len(intersection_rupture_ids) == len(expected_intersection_ruptures)
-
-        union_rupture_ids = sol.get_rupture_ids_for_location_radius(
-            location_ids=["WLG", "BHE"],
-            radius_km=100,
-            location_join_type=SetOperationEnum.UNION,
-        )
-        assert len(union_rupture_ids) == len(expected_union_ruptures)
-
-        # with raises(ValueError):
-        diff_rupture_ids = sol.get_rupture_ids_for_location_radius(
-            location_ids=["WLG", "BHE"],
-            radius_km=100,
-            location_join_type=SetOperationEnum.DIFFERENCE,
-        )
-        assert len(diff_rupture_ids) == len(expected_diff_ruptures)
-
     def test_slip_rate_soln(self, crustal_solution_fixture):
         sol = crustal_solution_fixture
 
@@ -183,16 +68,42 @@ class TestInversionSolution(object):
         assert "SlipRateStdDev" not in sol.solution_file.fault_sections.columns
         assert "Section Index" not in sol.solution_file.fault_sections.columns
 
+    def test_crustal_filter_solution(self, crustal_solution_fixture):
+        sol = crustal_solution_fixture
+
+        # take the first 5 ruptures and build a new solution
+        new_sol = InversionSolution.filter_solution(sol, sol.solution_file.ruptures.head(20)["Rupture Index"])
+        assert isinstance(new_sol, InversionSolution)
+        print(new_sol.solution_file.rupture_rates)
+        print(sol.solution_file.rupture_rates)
+        assert sol.solution_file.rupture_rates.head(20).all().all() == new_sol.solution_file.rupture_rates.all().all()
+
+    @pytest.mark.skip('placeholder for a future ticket')
+    def test_crustal_filter_solution_trimmed(self, crustal_solution_fixture):
+        # a trimmed sdolution has all the extra solution data (geojson etc) trimmed to match the ruptures changes,
+        #    let's list them here
+
+        sol = crustal_solution_fixture
+
+        # take the first N ruptures and build a new solution
+        N = 10
+        new_sol = InversionSolution.filter_solution(sol, sol.solution_file.ruptures.head(N)["Rupture Index"])
+        assert isinstance(new_sol, InversionSolution)
+        print(new_sol.solution_file.rupture_rates)
+        print(sol.solution_file.rupture_rates)
+        assert sol.solution_file.rupture_rates.head(N).all().all() == new_sol.solution_file.rupture_rates.all().all()
+
 
 class TestSmallPuyInversionSolution(object):
+
     def test_new_puysegur_filter_solution(self, puysegur_small_fixture):
         sol = puysegur_small_fixture
+
+        # take the first 5 ruptures and build a new solution
         new_sol = InversionSolution.filter_solution(sol, sol.solution_file.ruptures.head()["Rupture Index"])
         assert isinstance(new_sol, InversionSolution)
         print(new_sol.solution_file.rupture_rates)
         print(sol.solution_file.rupture_rates)
-
-        # What is this test doing??
         assert sol.solution_file.rupture_rates.head().all().all() == new_sol.solution_file.rupture_rates.all().all()
 
     def test_check_indexes(self, puysegur_small_fixture):

--- a/test/test_inversion_solution.py
+++ b/test/test_inversion_solution.py
@@ -68,6 +68,12 @@ class TestInversionSolution(object):
         assert "SlipRateStdDev" not in sol.solution_file.fault_sections.columns
         assert "Section Index" not in sol.solution_file.fault_sections.columns
 
+    def test_section_target_slip_rates(self, crustal_solution_fixture):
+        sol = crustal_solution_fixture
+        tss = sol.solution_file.section_target_slip_rates
+        assert tss is not None
+        assert tss.shape == sol.solution_file.section_target_slip_rates.shape
+
     def test_crustal_filter_solution(self, crustal_solution_fixture):
         sol = crustal_solution_fixture
 
@@ -81,7 +87,7 @@ class TestInversionSolution(object):
     @pytest.mark.skip('placeholder for a future ticket')
     def test_crustal_filter_solution_trimmed(self, crustal_solution_fixture):
         # a trimmed sdolution has all the extra solution data (geojson etc) trimmed to match the ruptures changes,
-        #    let's list them here
+        #  let's list them here
 
         sol = crustal_solution_fixture
 


### PR DESCRIPTION
In preparation for #72 

The main Protocol superclasses are now unnecessary and make code/doc maintenance harder. This PR removes them in preparation for final API changes.


