### PR TITLE
WORKAROUND: disable section_distance() 

### DIFF
--- a/solvis/geometry.py
+++ b/solvis/geometry.py
@@ -373,6 +373,9 @@ def section_distance(
 
     Where that surface is the surface projection of the fault.
 
+    WARNING: this function does not consider dip angle, assuming all faults to have dip = 90. For
+    now, use the surface projection method to approximate 3D distances.
+
     Args:
         transformer: typically from WGS84 to azimuthal
         surface_geometry: the surface projection of the fault plane (`Polygon` or `LineString`)

--- a/test/geometry/test_geometry_distance.py
+++ b/test/geometry/test_geometry_distance.py
@@ -140,6 +140,7 @@ class TestSurfaceDistanceCalculation(object):
         # print ( new_series.loc[lambda x: x <= 100000 ])
         assert new_series.min() == approx(38282.218 / 1e3)
 
+    @pytest.mark.skip('until 3d distance is figured out - currently dip angle is not considered.')
     @pytest.mark.parametrize('dist_km', [10, 20, 30, 50, 70, 100, 150, 180])
     def test_calc_crustal_compare_algorithms(self, dist_km):
 
@@ -171,7 +172,7 @@ class TestSurfaceDistanceCalculation(object):
 
         assert list(polygon_intersect_df['FaultID']) == list(gdf[gdf['distance_km'] <= dist_km]['FaultID'])
 
-    @pytest.mark.skip('until 3d distance is figured out')
+    @pytest.mark.skip('until 3d distance is figured out - currently dip angle is not considered.')
     @pytest.mark.parametrize('dist_km', [200, 300, 500, 1000])
     def test_calc_crustal_compare_algorithms_larger_distance(self, dist_km):
 


### PR DESCRIPTION
tests failing only on mac/windows. Add warning to tested function.

- closes #89
- closes #90

there's a new ticket #92 to resolve this issue.